### PR TITLE
Avoid failure when "configuration.properties" is not found

### DIFF
--- a/preprocess-extensions_template.xml
+++ b/preprocess-extensions_template.xml
@@ -14,7 +14,7 @@
        
        ========================================== -->
   
-  <loadproperties srcfile="${dita.dir}/lib/configuration.properties"/>
+  <loadproperties srcfile="${dita.dir}/lib/configuration.properties" unless:set="otversion" xmlns:unless="ant:unless"/>
   
   <condition property="isOT1.8.5">
     <equals arg1="${otversion}" arg2="1.8.5"/> 


### PR DESCRIPTION
Starting with DITA OT 3.1.2 the lib/configuration.properties will be removed but the "otversion" is already loaded by the build_init.xml so no need to load it.